### PR TITLE
Trim route terminus links in API response.

### DIFF
--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/IRoutingRepository.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/IRoutingRepository.kt
@@ -15,6 +15,12 @@ interface IRoutingRepository {
      * @param vehicleType vehicle type constraint for the route. Resulting route
      * must consist of only those infrastructure links that are safely
      * traversable by the given vehicle type.
+     * @param fractionalStartLocationOnFirstLink the location of route's start
+     * point as a fraction of the length of the first infrastructure link on the
+     * route. The fraction must be in range [0.0, 1.0].
+     * @param fractionalEndLocationOnLastLink the location of route's end point
+     * as a fraction of the length of the last infrastructure link on the route.
+     * The fraction must be in range [0.0, 1.0].
      * @param bufferAreaRestriction contains data with which geometrical
      * restriction for the target set of infrastructure links can be defined
      * while finding route through infrastructure network.
@@ -26,6 +32,8 @@ interface IRoutingRepository {
      */
     fun findRouteViaNetworkNodes(nodeIdSequence: NodeIdSequence,
                                  vehicleType: VehicleType,
+                                 fractionalStartLocationOnFirstLink: Double,
+                                 fractionalEndLocationOnLastLink: Double,
                                  bufferAreaRestriction: BufferAreaRestriction? = null)
-        : List<RouteLinkDTO>
+        : RouteDTO
 }

--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/RouteDTO.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/RouteDTO.kt
@@ -1,0 +1,24 @@
+package fi.hsl.jore4.mapmatching.repository.routing
+
+data class RouteDTO(val routeLinks: List<RouteLinkDTO>,
+                    val trimmedStartLink: RouteLinkDTO?,
+                    val trimmedEndLink: RouteLinkDTO?) {
+
+    /**
+     * Return route links using the trimmed versions of the first and the last
+     * link. Trimming is done using the fractional locations of snapped points.
+     */
+    fun getRouteLinksWithTrimmedTermini(): List<RouteLinkDTO> = when (routeLinks.size) {
+        0 -> emptyList()
+        1 -> listOf(trimmedStartLink ?: routeLinks.first())
+        else -> when {
+            routeLinks.size == 2 && trimmedStartLink == null && trimmedEndLink == null -> routeLinks
+            else -> {
+                val start: List<RouteLinkDTO> = trimmedStartLink?.let { listOf(it) } ?: emptyList()
+                val end: List<RouteLinkDTO> = trimmedEndLink?.let { listOf(it) } ?: emptyList()
+
+                start + routeLinks.drop(1).dropLast(1) + end
+            }
+        }
+    }
+}

--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/RouteLinkDTO.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/repository/routing/RouteLinkDTO.kt
@@ -4,5 +4,4 @@ import fi.hsl.jore4.mapmatching.model.InfrastructureLinkTraversal
 
 data class RouteLinkDTO(val routeSeqNum: Int,
                         val routeLegSeqNum: Int,
-                        val startNodeId: Long,
                         val linkTraversal: InfrastructureLinkTraversal)

--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/service/common/IRoutingServiceInternal.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/service/common/IRoutingServiceInternal.kt
@@ -1,9 +1,9 @@
 package fi.hsl.jore4.mapmatching.service.common
 
-import fi.hsl.jore4.mapmatching.model.InfrastructureLinkTraversal
 import fi.hsl.jore4.mapmatching.model.NodeIdSequence
 import fi.hsl.jore4.mapmatching.model.VehicleType
 import fi.hsl.jore4.mapmatching.repository.routing.BufferAreaRestriction
+import fi.hsl.jore4.mapmatching.repository.routing.RouteDTO
 
 interface IRoutingServiceInternal {
 
@@ -17,6 +17,12 @@ interface IRoutingServiceInternal {
      * @param vehicleType vehicle type constraint for the route. Resulting route
      * must consist of only those infrastructure links that are safely
      * traversable by the given vehicle type.
+     * @param fractionalStartLocationOnFirstLink the location of route's start
+     * point as a fraction of the length of the first infrastructure link on the
+     * route. The fraction must be in range [0.0, 1.0].
+     * @param fractionalEndLocationOnLastLink the location of route's end point
+     * as a fraction of the length of the last infrastructure link on the route.
+     * The fraction must be in range [0.0, 1.0].
      * @param bufferAreaRestriction contains data with which geometrical
      * restriction for the target set of infrastructure links can be defined
      * while finding route through infrastructure network.
@@ -27,6 +33,8 @@ interface IRoutingServiceInternal {
      */
     fun findRoute(nodeIdSequence: NodeIdSequence,
                   vehicleType: VehicleType,
+                  fractionalStartLocationOnFirstLink: Double,
+                  fractionalEndLocationOnLastLink: Double,
                   bufferAreaRestriction: BufferAreaRestriction? = null)
-        : List<InfrastructureLinkTraversal>
+        : RouteDTO
 }

--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/service/common/RoutingServiceInternalImpl.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/service/common/RoutingServiceInternalImpl.kt
@@ -1,11 +1,10 @@
 package fi.hsl.jore4.mapmatching.service.common
 
-import fi.hsl.jore4.mapmatching.model.InfrastructureLinkTraversal
 import fi.hsl.jore4.mapmatching.model.NodeIdSequence
 import fi.hsl.jore4.mapmatching.model.VehicleType
 import fi.hsl.jore4.mapmatching.repository.routing.BufferAreaRestriction
 import fi.hsl.jore4.mapmatching.repository.routing.IRoutingRepository
-import fi.hsl.jore4.mapmatching.repository.routing.RouteLinkDTO
+import fi.hsl.jore4.mapmatching.repository.routing.RouteDTO
 import fi.hsl.jore4.mapmatching.util.LogUtils.joinToLogString
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,14 +20,18 @@ class RoutingServiceInternalImpl @Autowired constructor(val routingRepository: I
     @Transactional(readOnly = true)
     override fun findRoute(nodeIdSequence: NodeIdSequence,
                            vehicleType: VehicleType,
+                           fractionalStartLocationOnFirstLink: Double,
+                           fractionalEndLocationOnLastLink: Double,
                            bufferAreaRestriction: BufferAreaRestriction?)
-        : List<InfrastructureLinkTraversal> {
+        : RouteDTO {
 
-        return routingRepository
-            .findRouteViaNetworkNodes(nodeIdSequence, vehicleType, bufferAreaRestriction)
-            .also { routeLinks: List<RouteLinkDTO> ->
-                LOGGER.debug { "Got route links for nodes $nodeIdSequence: ${joinToLogString(routeLinks)}" }
+        return routingRepository.findRouteViaNetworkNodes(nodeIdSequence,
+                                                          vehicleType,
+                                                          fractionalStartLocationOnFirstLink,
+                                                          fractionalEndLocationOnLastLink,
+                                                          bufferAreaRestriction)
+            .also { route: RouteDTO ->
+                LOGGER.debug { "Got route links for nodes $nodeIdSequence: ${joinToLogString(route.routeLinks)}" }
             }
-            .map(RouteLinkDTO::linkTraversal)
     }
 }


### PR DESCRIPTION
Trimming/cropping is done in order to get more accurate geometries and lengths for matched results compared to input route geometries. More accurate results aid in recognising the weakest matches in order to find issues with map-matching algorithm and/or Digiroad modeling compared to Jore3 infrastructure network.

The change does not affect e.g. Jore4 UI since individual links in the API response remain unchanged. In other words, the IDs, traversing directions and geometries of individual links are not affected. Only the compound route geometry and the length calculated based on it are changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-map-matching/25)
<!-- Reviewable:end -->
