### PR TITLE
Increase default value for buffer radius within map-matching from 50 …

### DIFF
--- a/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/api/MapMatchingController.kt
+++ b/spring-boot/src/main/kotlin/fi/hsl/jore4/mapmatching/api/MapMatchingController.kt
@@ -79,7 +79,7 @@ class MapMatchingController @Autowired constructor(val matchingService: IMatchin
         private const val TRANSPORTATION_MODE_PARAM = "{transportationMode:[a-zA-Z-_]+}"
         private const val VEHICLE_TYPE_PARAM = "{vehicleTypeParam:[a-zA-Z-_]+}"
 
-        private const val DEFAULT_BUFFER_RADIUS_IN_METERS: Double = 50.0
+        private const val DEFAULT_BUFFER_RADIUS_IN_METERS: Double = 55.0
         private const val DEFAULT_TERMINUS_LINK_QUERY_DISTANCE: Double = 50.0
         private const val DEFAULT_TERMINUS_LINK_QUERY_LIMIT: Int = 5
         private const val DEFAULT_MAX_STOP_LOCATION_DEVIATION: Double = 80.0


### PR DESCRIPTION
…m to 55 m.

In testing, the increase has a positive effect of raising map-matching coverage of Jore3 route directions from about 82% to 84%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-map-matching/34)
<!-- Reviewable:end -->
