### PR TITLE
Use JDK v17 in github workflows

### DIFF
--- a/.github/workflows/generate-jooq.yml
+++ b/.github/workflows/generate-jooq.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           java-package: jdk
           architecture: x64
           distribution: temurin

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Start databases (blocking until up)
         run: ./development.sh start:devdeps
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           java-package: jdk
           architecture: x64
           distribution: temurin


### PR DESCRIPTION
JDK/JRE 17 is a requirement for Spring Boot 3 to which we should migrate in the future (presumably prior to going production).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-map-matching/61)
<!-- Reviewable:end -->
