### PR TITLE
Update custom Docker Compose setup to use the new database image.

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -32,4 +32,4 @@ services:
       file: docker-compose.base.yml
       service: jore4-mapmatchingdb-base
     container_name: mapmatchingdb
-    image: "hsldevcom/jore4-postgres:mapmatching-main--20240905-5127bc444d3b324a8bb76f6fe3705166e9cf10ac"
+    image: "hsldevcom/jore4-postgres:mapmatching-main--20250425-c07c8632baab554dfbbbb64177ed930282094232"


### PR DESCRIPTION
The image parameter `DIGIROAD_ROUTING_DUMP_VERSION` was replaced by `DIGIROAD_ROUTING_DUMP_URL`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-map-matching/89)
<!-- Reviewable:end -->
